### PR TITLE
fix(con): mentors accept requests only within selected capacity

### DIFF
--- a/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
+++ b/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
@@ -5,7 +5,7 @@ import {
 } from '@talent-connect/shared-atomic-design-components'
 import { useFormik } from 'formik'
 import { useState } from 'react'
-import { Content } from 'react-bulma-components'
+import { Content, Notification } from 'react-bulma-components'
 import { useQueryClient } from 'react-query'
 import { useHistory } from 'react-router-dom'
 import * as Yup from 'yup'
@@ -17,7 +17,8 @@ import {
 interface ConfirmMentorshipProps {
   match: ConfirmMentorshipMatchPropFragment
   menteeName?: string
-  hasReachedMenteeLimit?: boolean
+  hasReachedDesiredMenteeLimit?: boolean
+  menteeCountCapacity?: number
 }
 
 interface ConfirmMentorshipFormValues {
@@ -30,6 +31,7 @@ const initialValues = {
 
 const MIN_CHARS_COUNT = 250
 const MAX_CHARS_COUNT = 600
+const MAX_MENTEE_LIMIT = 2
 
 const validationSchema = Yup.object({
   mentorReplyMessageOnAccept: Yup.string()
@@ -40,7 +42,8 @@ const validationSchema = Yup.object({
 
 const ConfirmMentorship = ({
   match,
-  hasReachedMenteeLimit,
+  hasReachedDesiredMenteeLimit,
+  menteeCountCapacity,
 }: ConfirmMentorshipProps) => {
   const queryClient = useQueryClient()
   const acceptMentorshipMutation = useAcceptMentorshipMutation()
@@ -77,12 +80,32 @@ const ConfirmMentorship = ({
 
   return (
     <>
-      <Button
-        onClick={() => setModalActive(true)}
-        disabled={hasReachedMenteeLimit}
-      >
-        Accept
-      </Button>
+      {hasReachedDesiredMenteeLimit ? (
+        <>
+          {hasReachedDesiredMenteeLimit &&
+          menteeCountCapacity === MAX_MENTEE_LIMIT ? (
+            <Notification color="info" className="is-light">
+              You've reached our recommended maximum number of mentees. If you
+              wish to mentor more than 2 mentees at the same time, please reach
+              out to us at{' '}
+              <a href="mailto:career@redi-school.org">career@redi-school.org</a>
+              . Otherwise, please decline the application.
+            </Notification>
+          ) : (
+            <Notification color="info" className="is-light">
+              You've reached your desired number of mentees. If you wish to
+              accept another mentee, please go to the{' '}
+              <a onClick={() => history.push('/app/me')}>My Profile</a> page and
+              increase the mentee count value. Otherwise, please decline the
+              application.
+            </Notification>
+          )}
+          <Button disabled={hasReachedDesiredMenteeLimit}>Accept</Button>
+        </>
+      ) : (
+        <Button onClick={() => setModalActive(true)}>Accept</Button>
+      )}
+
       <Modal
         show={isModalActive}
         stateFn={setModalActive}

--- a/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
+++ b/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
@@ -82,8 +82,7 @@ const ConfirmMentorship = ({
     <>
       {hasReachedDesiredMenteeLimit ? (
         <>
-          {hasReachedDesiredMenteeLimit &&
-          menteeCountCapacity === MAX_MENTEE_LIMIT ? (
+          {menteeCountCapacity === MAX_MENTEE_LIMIT ? (
             <Notification color="info" className="is-light">
               You've reached our recommended maximum number of mentees. If you
               wish to mentor more than 2 mentees at the same time, please reach

--- a/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
+++ b/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
@@ -17,6 +17,7 @@ import {
 interface ConfirmMentorshipProps {
   match: ConfirmMentorshipMatchPropFragment
   menteeName?: string
+  hasReachedMenteeLimit?: boolean
 }
 
 interface ConfirmMentorshipFormValues {
@@ -37,7 +38,10 @@ const validationSchema = Yup.object({
     .max(MAX_CHARS_COUNT),
 })
 
-const ConfirmMentorship = ({ match }: ConfirmMentorshipProps) => {
+const ConfirmMentorship = ({
+  match,
+  hasReachedMenteeLimit,
+}: ConfirmMentorshipProps) => {
   const queryClient = useQueryClient()
   const acceptMentorshipMutation = useAcceptMentorshipMutation()
   const [isModalActive, setModalActive] = useState(false)
@@ -73,7 +77,12 @@ const ConfirmMentorship = ({ match }: ConfirmMentorshipProps) => {
 
   return (
     <>
-      <Button onClick={() => setModalActive(true)}>Accept</Button>
+      <Button
+        onClick={() => setModalActive(true)}
+        disabled={hasReachedMenteeLimit}
+      >
+        Accept
+      </Button>
       <Modal
         show={isModalActive}
         stateFn={setModalActive}

--- a/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
@@ -32,10 +32,10 @@ const ApplicationCard = ({ application }: Props) => {
   const loopbackUserId = getAccessTokenFromLocalStorage().userId
   const myProfileQuery = useLoadMyProfileQuery({ loopbackUserId })
 
-  const hasReachedMenteeLimit =
+  const hasReachedDesiredMenteeLimit =
     myProfileQuery.data.conProfile.doesNotHaveAvailableMentorshipSlot
 
-  console.log('hasReachedMenteeLimit', hasReachedMenteeLimit)
+  const menteeCountCapacity = myProfileQuery.data.conProfile.menteeCountCapacity
 
   const currentUser = myProfileQuery.data.conProfile
 
@@ -152,7 +152,8 @@ const ApplicationCard = ({ application }: Props) => {
           <>
             <ConfirmMentorship
               match={application}
-              hasReachedMenteeLimit={hasReachedMenteeLimit}
+              hasReachedDesiredMenteeLimit={hasReachedDesiredMenteeLimit}
+              menteeCountCapacity={menteeCountCapacity}
             />
             <DeclineMentorshipButton match={application} />
           </>

--- a/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
@@ -34,6 +34,9 @@ const ApplicationCard = ({ application }: Props) => {
 
   const hasReachedMenteeLimit =
     myProfileQuery.data.conProfile.doesNotHaveAvailableMentorshipSlot
+
+  console.log('hasReachedMenteeLimit', hasReachedMenteeLimit)
+
   const currentUser = myProfileQuery.data.conProfile
 
   const {
@@ -147,7 +150,10 @@ const ApplicationCard = ({ application }: Props) => {
         {currentUserIsMentor &&
         application.status === MentorshipMatchStatus.Applied ? (
           <>
-            <ConfirmMentorship match={application} />
+            <ConfirmMentorship
+              match={application}
+              hasReachedMenteeLimit={hasReachedMenteeLimit}
+            />
             <DeclineMentorshipButton match={application} />
           </>
         ) : null}

--- a/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.tsx
@@ -29,6 +29,11 @@ function MobileApplicationCard({ application }: Props) {
   const loopbackUserId = getAccessTokenFromLocalStorage().userId
   const myProfileQuery = useLoadMyProfileQuery({ loopbackUserId })
 
+  const hasReachedDesiredMenteeLimit =
+    myProfileQuery.data.conProfile.doesNotHaveAvailableMentorshipSlot
+
+  const menteeCountCapacity = myProfileQuery.data.conProfile.menteeCountCapacity
+
   const currentUser = myProfileQuery.data.conProfile
 
   const {
@@ -139,7 +144,11 @@ function MobileApplicationCard({ application }: Props) {
         application.status === MentorshipMatchStatus.Applied ? (
           <div className="action-buttons">
             <div>
-              <ConfirmMentorship match={application} />
+              <ConfirmMentorship
+                match={application}
+                hasReachedDesiredMenteeLimit={hasReachedDesiredMenteeLimit}
+                menteeCountCapacity={menteeCountCapacity}
+              />
               <DeclineMentorshipButton match={application} />
             </div>
           </div>


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes #997

## What should the reviewer know?

When the mentor receives new mentee applications but has reached the mentee count they selected in their profile (or has reached our recommended mentee limit - 2 mentees), we disable the `Accept` button on the mentee's application and display the notification.

## Screenshots

A mentor who has one ongoing mentorship & selected 1 in the mentee count:
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/22a82f8e-ba92-4f71-b9a0-80b0bf4cf060" />
<img width="394" alt="image" src="https://github.com/user-attachments/assets/f9ccb14f-ff17-4683-b98f-9bde77899fff" />

 A mentor who has two ongoing mentorships & selected 2 (our recommended maximum number of mentees) in the mentee count:
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/7b310535-9ef5-41f9-bf6a-1dba05417edc" />
<img width="349" alt="image" src="https://github.com/user-attachments/assets/0c44d8f8-eae5-4225-9e3b-093d636673d0" />
