### PR TITLE
chore(con): replace calendar links and emails

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/footer.malmo.team.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/footer.malmo.team.mjml
@@ -33,8 +33,9 @@
               >
               <br />
               Mentorship Program Manager -
-              <a href="mailto:alice.r@redi-school.org" class="text-link"
-              >alice.r@redi-school.org</a>
+              <a href="mailto:gloria@redi-school.org" class="text-link"
+                >gloria@redi-school.org</a
+              >
               <br /><br />
               <strong>Visiting address:</strong><br />
               ReDI School of Digital Integration Malmö<br />

--- a/apps/redi-connect/src/assets/locales/en/translation.json
+++ b/apps/redi-connect/src/assets/locales/en/translation.json
@@ -80,7 +80,7 @@
           },
           {
             "question": "If I have any questions, whom should I contact?",
-            "answer": "If you are from <b>ReDI School Germany</b>, then please use the following email addresses: </br> General: <a href='mailto:career@redi-school.org'>career@redi-school.org</a> </br> Mentorship Program Manager: <a href='mailto:hadeer@redi-school.org'>hadeer@redi-school.org</a></br></br>If you are from <b>ReDI School Malmö</b>, then please use the following email addresses:</br>General: <a href='mailto:malmo@redi-school.org'>malmo@redi-school.org</a></br>General career: <a href='mailto:career.sweden@redi-school.org'>career.sweden@redi-school.org</a></br>Mentorship Program Manager: <a href='mailto:alice.r@redi-school.org'>alice.r@redi-school.org</a>"
+            "answer": "If you are from <b>ReDI School Germany</b>, then please use the following email addresses: </br> General: <a href='mailto:career@redi-school.org'>career@redi-school.org</a> </br> Mentorship Program Manager: <a href='mailto:hadeer@redi-school.org'>hadeer@redi-school.org</a></br></br>If you are from <b>ReDI School Malmö</b>, then please use the following email addresses:</br>General: <a href='mailto:malmo@redi-school.org'>malmo@redi-school.org</a></br>General career: <a href='mailto:career.sweden@redi-school.org'>career.sweden@redi-school.org</a></br>Mentorship Program Manager: <a href='mailto:gloria@redi-school.org'>gloria@redi-school.org</a>"
           },
           {
             "question": "Is the mentorship service at ReDI School free of charge?",

--- a/apps/redi-connect/src/pages/app/me/onboarding-steps-config.tsx
+++ b/apps/redi-connect/src/pages/app/me/onboarding-steps-config.tsx
@@ -62,7 +62,7 @@ export const ONBOARDING_STEPS = [
             href={
               rediLocation === RediLocation.Malmo
                 ? 'https://calendar.app.google/u7EEPxtDVqif32Gz7'
-                : 'https://calendar.app.google/U1q1hfhfC3qdkkpq9'
+                : 'https://calendar.app.google/trzf6nYRHWifz8wa9'
             }
             target="__blank"
           >


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

We had changes in the team that required the following changes in the platform:

- Update Malmö Mentorship Program Manager's email address to `gloria@redi-school.org`
- Replace the calendar link for mentors in Germany from Hadeer's to Jenny's calendar link 