### PR TITLE
chore(con): add onboarding calls calendar link to the mentors emails

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.malmo.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.malmo.mjml
@@ -24,16 +24,21 @@
           </mj-text>
 
           <mj-text mj-class="text paragraph"
-            >After sending your profile for review and having an onboarding call
-            with our Mentorship Program Manager, your profile will become
-            visible to mentees.</mj-text
+            >After submitting your profile for review, please
+            <a
+              href="https://calendar.app.google/u7EEPxtDVqif32Gz7"
+              class="text-link"
+              >book a quick onboarding session</a
+            >
+            with our Mentorship Program Manager. This is the last step before
+            your profile will become visible to mentees.</mj-text
           >
 
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">ReDI Malmö Team</mj-text>
         </mj-column>
       </mj-section>
-       <mj-include path="./footer.malmo.team.mjml" />
+      <mj-include path="./footer.malmo.team.mjml" />
       <mj-section />
     </mj-wrapper>
   </mj-body>

--- a/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.mjml
@@ -24,9 +24,14 @@
           </mj-text>
 
           <mj-text mj-class="text paragraph"
-            >After sending your profile for review and having an onboarding call
-            with our Mentorship Program Manager, your profile will become
-            visible to mentees.</mj-text
+            >After submitting your profile for review, please
+            <a
+              href="https://calendar.app.google/trzf6nYRHWifz8wa9"
+              class="text-link"
+              >book a quick onboarding session</a
+            >
+            with our Mentorship Program Manager. This is the last step before
+            your profile will become visible to mentees.</mj-text
           >
 
           <mj-text mj-class="text">All the best,</mj-text>

--- a/apps/redi-connect/src/pages/app/me/onboarding-steps-config.tsx
+++ b/apps/redi-connect/src/pages/app/me/onboarding-steps-config.tsx
@@ -109,7 +109,7 @@ export const ONBOARDING_STEPS = [
           <a
             href={
               rediLocation === RediLocation.Malmo
-                ? 'https://calendar.app.google/zQJr8PJsNF2arm236'
+                ? 'https://calendar.app.google/u7EEPxtDVqif32Gz7'
                 : 'https://calendar.app.google/TsxN3Bp1PGVnMrx96'
             }
             target="_blank"


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

This PR brings back the onboarding calls calendar link to the mentors' emails.

## Screenshots

German mentors:
![image](https://github.com/user-attachments/assets/8ffb1f51-8d1e-4d9d-a69a-d280b848f7b3)

Malmö mentors:
![image](https://github.com/user-attachments/assets/82847f38-2f97-497c-ba29-66c2174c35d5)

