### PR TITLE
fix(con): send the pending-review-declined-email on status change from submitted for review to rejected

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/pending-review-declined-email.malmo.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/pending-review-declined-email.malmo.mjml
@@ -13,18 +13,17 @@
             >Dear ${firstName},</mj-text
           >
           <mj-text mj-class="text paragraph"
-            >unfortunately your profile has not been approved. Most likely this
-            has been discussed with you in your conversation with one of our
-            ReDI Talent Success team members.</mj-text
+            >Unfortunately, your profile has not been approved. Most likely,
+            this has been discussed with you during your conversation with one
+            of our ReDI Talent Success team members.</mj-text
           >
 
           <mj-text mj-class="text paragraph"
-            >If you feel like this has been done without your knowledge, please
-            reach out to us at
+            >If you need further clarification, please reach out to us at
             <a href="mailto:career.sweden@redi-school.org" class="text-link"
               >career.sweden@redi-school.org</a
             >
-            so we can get in touch with you.</mj-text
+            so that we can get in touch with you.</mj-text
           >
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">ReDI Malmö Team</mj-text>

--- a/apps/nestjs-api/src/assets/email/templates/pending-review-declined-email.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/pending-review-declined-email.mjml
@@ -20,8 +20,8 @@
 
           <mj-text mj-class="text paragraph"
             >If you need further clarification, please reach out to us at
-            <a href="mailto:career.sweden@redi-school.org" class="text-link"
-              >career.sweden@redi-school.org</a
+            <a href="mailto:career@redi-school.org" class="text-link"
+              >career@redi-school.org</a
             >
             so that we can get in touch with you.</mj-text
           >

--- a/apps/nestjs-api/src/assets/email/templates/pending-review-declined-email.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/pending-review-declined-email.mjml
@@ -13,16 +13,17 @@
             >Dear ${firstName},</mj-text
           >
           <mj-text mj-class="text paragraph"
-            >Unfortunately, your profile has not been approved. Most likely this
-            has been discussed with you in your conversation with one of our
-            ReDI Talent Success team members.
-          </mj-text>
+            >Unfortunately, your profile has not been approved. Most likely,
+            this has been discussed with you during your conversation with one
+            of our ReDI Talent Success team members.</mj-text
+          >
+
           <mj-text mj-class="text paragraph"
-            >If you feel like this has been done without your knowledge, please
-            reach out to us at
-            <a href="mailto:career@redi-school.org" class="text-link"
-              >career@redi-school.org</a
-            >, so we can get in touch with you.</mj-text
+            >If you need further clarification, please reach out to us at
+            <a href="mailto:career.sweden@redi-school.org" class="text-link"
+              >career.sweden@redi-school.org</a
+            >
+            so that we can get in touch with you.</mj-text
           >
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">Your ReDI Talent Success Team</mj-text>

--- a/apps/nestjs-api/src/con-profiles/con-profiles-salesforce-event-handler.service.ts
+++ b/apps/nestjs-api/src/con-profiles/con-profiles-salesforce-event-handler.service.ts
@@ -32,8 +32,8 @@ export class ConProfilesSalesforceEventHandlerService {
     const isStatusSubmittedForReviewToApproved =
       payload.oldStatus === ConnectProfileStatus.SUBMITTED_FOR_REVIEW &&
       payload.newStatus === ConnectProfileStatus.APPROVED
-    const isStatusDraftingToRejected =
-      payload.oldStatus === ConnectProfileStatus.DRAFTING_PROFILE &&
+    const isStatusSubmittedForReviewToRejected =
+      payload.oldStatus === ConnectProfileStatus.SUBMITTED_FOR_REVIEW &&
       payload.newStatus === ConnectProfileStatus.REJECTED
 
     if (isStatusSubmittedForReviewToApproved) {
@@ -53,7 +53,7 @@ export class ConProfilesSalesforceEventHandlerService {
             firstName: conProfile.props.firstName,
             rediLocation: conProfile.props.rediLocation,
           })
-        if (isStatusDraftingToRejected)
+        if (isStatusSubmittedForReviewToRejected)
           this.emailService.sendPendingReviewDeclinedEmail({
             recipient: conProfile.props.email,
             firstName: conProfile.props.firstName,
@@ -69,7 +69,7 @@ export class ConProfilesSalesforceEventHandlerService {
             firstName: conProfile.props.firstName,
             rediLocation: conProfile.props.rediLocation,
           })
-        if (isStatusDraftingToRejected)
+        if (isStatusSubmittedForReviewToRejected)
           this.emailService.sendPendingReviewDeclinedEmail({
             recipient: conProfile.props.email,
             firstName: conProfile.props.firstName,


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

Before introducing a `Submitted for review` profile status on CON, we sent the ‘Your user registration was declined’ email when the profile status was changed from `Drafting` to `Rejected`. The profile review process has changed, and now Mentorship Managers only review the profiles with a `Submitted for review` status. Therefore, we had to update the condition for sending the  ‘Your user registration was declined’ email to the following:

We send the ‘Your user registration was declined’ email when the profile status is changed from `Submitted for review` to `Rejected`.

Also, the wording of that email was updated.

## Screenshots
![image](https://github.com/user-attachments/assets/d08eba00-7d60-4716-80d3-a7b16e3b12b1)

![image](https://github.com/user-attachments/assets/91514893-429a-4976-a284-2807aeeb4280)
