### PR TITLE
bugfix(con): hide apply button from unapproved mentees; hide optOutOfMenteesFromOtherRediLocation info from mentor's profile page

### DIFF
--- a/apps/redi-connect/src/components/molecules/ReadMenteeCount.tsx
+++ b/apps/redi-connect/src/components/molecules/ReadMenteeCount.tsx
@@ -1,5 +1,4 @@
 import { ConProfile, useLoadMyProfileQuery } from '@talent-connect/data-access'
-import { REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
 import { Content } from 'react-bulma-components'
 import { getAccessTokenFromLocalStorage } from '../../services/auth/auth'
 
@@ -15,13 +14,14 @@ interface Props {
 function Me({ profile }: Props) {
   const {
     menteeCountCapacity,
-    optOutOfMenteesFromOtherRediLocation,
-    rediLocation,
+    // optOutOfMenteesFromOtherRediLocation,
+    // rediLocation,
   } = profile
 
   return (
     <Content>
       {menteeCountCapacity && <p>{menteeCountCapacity}</p>}
+      {/* We decided to temporary hide this as the majority of students are taking classes online
       {!optOutOfMenteesFromOtherRediLocation && (
         <p>
           Let mentees in my location ({REDI_LOCATION_NAMES[rediLocation]}) AND
@@ -33,7 +33,7 @@ function Me({ profile }: Props) {
           Only let mentees from my own location (
           {REDI_LOCATION_NAMES[rediLocation]}) apply for mentorship
         </p>
-      )}
+      )} */}
     </Content>
   )
 }

--- a/apps/redi-connect/src/components/organisms/EditableMenteeCount.tsx
+++ b/apps/redi-connect/src/components/organisms/EditableMenteeCount.tsx
@@ -3,14 +3,10 @@ import {
   usePatchMyProfileMutation,
 } from '@talent-connect/data-access'
 import {
-  Checkbox,
   Editable,
   FormSelect,
 } from '@talent-connect/shared-atomic-design-components'
-import {
-  MENTEE_COUNT_CAPACITY_OPTIONS,
-  REDI_LOCATION_NAMES,
-} from '@talent-connect/shared-config'
+import { MENTEE_COUNT_CAPACITY_OPTIONS } from '@talent-connect/shared-config'
 import { FormikValues, useFormik } from 'formik'
 import { useQueryClient } from 'react-query'
 import * as Yup from 'yup'
@@ -37,7 +33,7 @@ const formMenteeCountCapacityOptions = MENTEE_COUNT_CAPACITY_OPTIONS.map(
 
 export interface AboutFormValues {
   menteeCountCapacity: number
-  optOutOfMenteesFromOtherRediLocation: boolean
+  // optOutOfMenteesFromOtherRediLocation: boolean
 }
 
 const validationSchema = Yup.object({
@@ -59,9 +55,9 @@ function EditableMenteeCount() {
   const profile = myProfileQuery.data?.conProfile
 
   const menteeCountCapacity = profile?.menteeCountCapacity
-  const optOutOfMenteesFromOtherRediLocation =
-    profile?.optOutOfMenteesFromOtherRediLocation
-  const rediLocation = profile?.rediLocation
+  // const optOutOfMenteesFromOtherRediLocation =
+  //   profile?.optOutOfMenteesFromOtherRediLocation
+  // const rediLocation = profile?.rediLocation
 
   const submitForm = async (values: FormikValues) => {
     const mutationResult = await patchMyProfileMutation.mutateAsync({
@@ -74,7 +70,7 @@ function EditableMenteeCount() {
 
   const initialValues: AboutFormValues = {
     menteeCountCapacity,
-    optOutOfMenteesFromOtherRediLocation,
+    // optOutOfMenteesFromOtherRediLocation,
   }
 
   const formik = useFormik({
@@ -88,7 +84,7 @@ function EditableMenteeCount() {
 
   return (
     <Editable
-      title="Mentee Count and Location"
+      title="Mentee Count"
       onSave={() => formik.handleSubmit()}
       onClose={() => formik.resetForm()}
       savePossible={formik.dirty && formik.isValid}
@@ -101,14 +97,15 @@ function EditableMenteeCount() {
         items={formMenteeCountCapacityOptions}
         formik={formik}
       />
-      <Checkbox.Form
+      {/* We decided to temporary hide this as the majority of students are taking classes online
+     <Checkbox.Form
         name="optOutOfMenteesFromOtherRediLocation"
         checked={formik.values.optOutOfMenteesFromOtherRediLocation}
         {...formik}
       >
         Only let mentees from my own city/location apply for mentorship (i.e.
         people in {REDI_LOCATION_NAMES[rediLocation]})
-      </Checkbox.Form>
+      </Checkbox.Form> */}
     </Editable>
   )
 }

--- a/apps/redi-connect/src/pages/app/profile/profile-viewer/ProfileViewer.tsx
+++ b/apps/redi-connect/src/pages/app/profile/profile-viewer/ProfileViewer.tsx
@@ -92,8 +92,13 @@ function ProfileViewer() {
   const hasOpenApplication =
     myMatchWithThisProfile?.status === MentorshipMatchStatus.Applied
 
+  const hasApprovedProfile = myProfile.profileStatus === 'APPROVED'
+
   const userCanApplyForMentorship =
-    !isAcceptedMatch && currentUserIsMentee && !hasOpenApplication
+    !isAcceptedMatch &&
+    currentUserIsMentee &&
+    !hasOpenApplication &&
+    hasApprovedProfile
 
   const shouldHidePrivateContactInfo = currentUserIsMentee && !isAcceptedMatch
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

In this PR, we:

- Hide the `Apply for this mentor` button from the mentees who don't have an approved profile
- Hide information related to `optOutOfMenteesFromOtherRediLocation` from the mentor's profile page, as currently the majority of our students are taking classes online