### PR TITLE
feat(con/tp): update cyberspace location naming; style mentee application card; style and add variants to the Chip component

### DIFF
--- a/apps/redi-connect/src/components/organisms/ConUserProfileCard.tsx
+++ b/apps/redi-connect/src/components/organisms/ConUserProfileCard.tsx
@@ -29,7 +29,7 @@ const ConUserProfileCard = ({
     categories,
   } = profile
   const tags = categories.map((category) => CATEGORIES_MAP[category])
-  const location = `ReDI ${REDI_LOCATION_NAMES[rediLocation]}`
+  const location = `${REDI_LOCATION_NAMES[rediLocation]}`
   const avatar = profileAvatarImageS3Key || placeholderImage
 
   return (

--- a/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.scss
+++ b/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.scss
@@ -2,6 +2,10 @@
 @import '_variables.scss';
 
 .application-card {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  justify-content: space-between;
   padding: $block-spacing;
   border-radius: $radius;
   transition: $transition;
@@ -16,23 +20,50 @@
     margin-bottom: $block-spacing;
   }
 
-  // not happy with the solution, time for refactoring together with avatar
-  &__avatar {
-    flex-grow: 0;
+  &__avatar-container,
+  &__tag-container {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    gap: 16px;
+    justify-content: space-between;
+  }
 
-    .avatar {
-      width: 4rem;
-      height: 4rem;
-    }
+  &__avatar {
+    width: 4rem;
+    height: 4rem;
   }
 
   &__link {
     font-weight: $weight-bold;
     color: $primary;
+    text-decoration: underline;
+    padding-bottom: 6px;
 
     &:hover {
-      text-decoration: underline;
+      color: $black;
     }
+  }
+
+  &__location {
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 6px;
+
+    &-icon {
+      position: relative;
+      left: -3px;
+    }
+
+    &-name {
+      font-size: 12px;
+      color: $grey;
+    }
+  }
+
+  &__date {
+    font-size: 12px;
+    color: $grey;
   }
 
   &-details {
@@ -49,10 +80,12 @@
   }
 
   &-dropdown {
-    flex-grow: 0;
-
     .icon {
       transition: $transition;
+
+      path {
+        fill: $black;
+      }
 
       &--rotate {
         transform: rotate(180deg);
@@ -63,9 +96,5 @@
   &-pending {
     @extend .application-card;
     border: 1px solid $redi-orange-dark;
-
-    &__status {
-      color: #fd4d00;
-    }
   }
 }

--- a/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
@@ -1,13 +1,13 @@
 import classnames from 'classnames'
 import moment from 'moment'
-import { Columns, Content, Heading } from 'react-bulma-components'
+import { Content, Heading } from 'react-bulma-components'
 
 import {
   AllConProfileFieldsFragment,
   MentorshipMatchStatus,
   useLoadMyProfileQuery,
 } from '@talent-connect/data-access'
-import { Icon } from '@talent-connect/shared-atomic-design-components'
+import { Chip, Icon } from '@talent-connect/shared-atomic-design-components'
 import {
   MENTORSHIP_MATCH_STATUS_LABELS,
   REDI_LOCATION_NAMES,
@@ -61,58 +61,57 @@ const ApplicationCard = ({ application }: Props) => {
         }
         onClick={() => setShowDetails(!showDetails)}
       >
-        <Columns vCentered>
-          <Columns.Column className="application-card__avatar">
+        <div className="application-card__avatar-container">
+          <div className="application-card__avatar">
             <Avatar profile={applicationUser} />
-          </Columns.Column>
+          </div>
 
-          <Columns.Column size={3} textAlignment="left">
+          <div>
             {applicationUser && (
               <>
-                <p>{applicationUser.fullName}</p>
-                <p>{REDI_LOCATION_NAMES[applicationUser.rediLocation]}</p>
+                <p
+                  className="application-card__link"
+                  onClick={() =>
+                    history.push(
+                      `/app/applications/profile/${
+                        applicationUser && applicationUser.id
+                      }`
+                    )
+                  }
+                >
+                  {applicationUser.fullName}
+                </p>
+                <div className="application-card__location">
+                  <Icon
+                    icon="location"
+                    size="small"
+                    className="application-card__location-icon"
+                  />
+                  <p className="application-card__location-name">
+                    {REDI_LOCATION_NAMES[applicationUser.rediLocation]}
+                  </p>
+                </div>
+                <p className="application-card__date">
+                  Sent on {moment(applicationDate).format('DD.MM.YYYY')}
+                </p>
               </>
             )}
-          </Columns.Column>
+          </div>
+        </div>
 
-          <Columns.Column textAlignment="centered">
-            <span
-              className="application-card__link"
-              onClick={() =>
-                history.push(
-                  `/app/applications/profile/${
-                    applicationUser && applicationUser.id
-                  }`
-                )
-              }
-            >
-              Visit Profile
-            </span>
-          </Columns.Column>
+        <div className="application-card__tag-container">
+          <div className="application-card__tag">
+            <Chip chip={MENTORSHIP_MATCH_STATUS_LABELS[application.status]} />
+          </div>
 
-          <Columns.Column textAlignment="centered" tablet={{ narrow: true }}>
-            From {moment(applicationDate).format('DD.MM.YYYY')}
-          </Columns.Column>
-
-          <Columns.Column
-            className={
-              application.status === MentorshipMatchStatus.Applied
-                ? 'application-card-pending__status'
-                : null
-            }
-            textAlignment="centered"
-          >
-            {MENTORSHIP_MATCH_STATUS_LABELS[application.status]}
-          </Columns.Column>
-
-          <Columns.Column className="application-card-dropdown">
+          <div className="application-card-dropdown">
             <Icon
               icon="chevronDown"
-              size="small"
+              size="medium"
               className={classnames({ 'icon--rotate': showDetails })}
             />
-          </Columns.Column>
-        </Columns>
+          </div>
+        </div>
       </div>
 
       <div

--- a/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/ApplicationCard.tsx
@@ -46,6 +46,7 @@ const ApplicationCard = ({ application }: Props) => {
     applicationUser,
     applicationDate,
     currentUserIsMentor,
+    chipVariant,
   } = useApplicationCard({
     application,
     currentUser,
@@ -100,9 +101,10 @@ const ApplicationCard = ({ application }: Props) => {
         </div>
 
         <div className="application-card__tag-container">
-          <div className="application-card__tag">
-            <Chip chip={MENTORSHIP_MATCH_STATUS_LABELS[application.status]} />
-          </div>
+          <Chip
+            variant={chipVariant}
+            chip={MENTORSHIP_MATCH_STATUS_LABELS[application.status]}
+          />
 
           <div className="application-card-dropdown">
             <Icon

--- a/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.scss
+++ b/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.scss
@@ -2,6 +2,10 @@
 @import '_variables.scss';
 
 .mobile-application-card {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  justify-content: space-between;
   padding: $column-gap;
   border-radius: $radius;
   transition: $transition;
@@ -16,23 +20,52 @@
     margin-bottom: $block-spacing;
   }
 
-  &__avatar {
-    flex-grow: 0;
+  &__avatar-container,
+  &__tag-container {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    gap: 12px;
+    justify-content: space-between;
+  }
 
-    .avatar {
-      width: 4rem;
-      height: 4rem;
-      z-index: 0;
-    }
+  &__avatar {
+    width: 3rem;
+    height: 3rem;
+    z-index: 0;
   }
 
   &__link {
+    font-size: 14px;
     font-weight: $weight-bold;
     color: $primary;
+    text-decoration: underline;
+    padding-bottom: 6px;
 
     &:hover {
-      text-decoration: underline;
+      color: $black;
     }
+  }
+
+  &__location {
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 6px;
+
+    &-icon {
+      position: relative;
+      left: -3px;
+    }
+
+    &-name {
+      font-size: 12px;
+      color: $grey;
+    }
+  }
+
+  &__date {
+    font-size: 12px;
+    color: $grey;
   }
 
   &-details {
@@ -48,10 +81,12 @@
   }
 
   &-dropdown {
-    flex-grow: 0;
-
     .icon {
       transition: $transition;
+
+      path {
+        fill: $black;
+      }
 
       &--rotate {
         transform: rotate(180deg);
@@ -62,10 +97,6 @@
   &-pending {
     @extend .mobile-application-card;
     border: 1px solid $redi-orange-dark;
-
-    &__status {
-      color: #fd4d00;
-    }
   }
 }
 
@@ -75,8 +106,4 @@
   justify-content: flex-end;
   padding-bottom: 8px;
   gap: 30px;
-}
-
-.mobile-column {
-  padding-left: 0;
 }

--- a/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.tsx
@@ -43,6 +43,7 @@ function MobileApplicationCard({ application }: Props) {
     applicationUser,
     applicationDate,
     currentUserIsMentor,
+    chipVariant,
   } = useApplicationCard({
     application,
     currentUser,
@@ -96,9 +97,10 @@ function MobileApplicationCard({ application }: Props) {
         </div>
 
         <div className="mobile-application-card__tag-container">
-          <div className="mobile-application-card__tag">
-            <Chip chip={MENTORSHIP_MATCH_STATUS_LABELS[application.status]} />
-          </div>
+          <Chip
+            variant={chipVariant}
+            chip={MENTORSHIP_MATCH_STATUS_LABELS[application.status]}
+          />
           <div className="mobile-application-card-dropdown">
             <Icon
               icon="chevronDown"

--- a/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.tsx
+++ b/apps/redi-connect/src/pages/app/applications/application-card/MobileApplicationCard.tsx
@@ -1,12 +1,12 @@
 import classnames from 'classnames'
 import moment from 'moment'
-import { Columns, Content, Heading } from 'react-bulma-components'
+import { Content, Heading } from 'react-bulma-components'
 
 import {
   MentorshipMatchStatus,
   useLoadMyProfileQuery,
 } from '@talent-connect/data-access'
-import { Icon } from '@talent-connect/shared-atomic-design-components'
+import { Chip, Icon } from '@talent-connect/shared-atomic-design-components'
 import {
   MENTORSHIP_MATCH_STATUS_LABELS,
   REDI_LOCATION_NAMES,
@@ -58,54 +58,55 @@ function MobileApplicationCard({ application }: Props) {
         }
         onClick={() => setShowDetails(!showDetails)}
       >
-        <Columns breakpoint="mobile" multiline={false} vCentered>
-          <Columns.Column className="mobile-application-card__avatar">
+        <div className="mobile-application-card__avatar-container">
+          <div className="mobile-application-card__avatar">
             <Avatar profile={applicationUser} />
-          </Columns.Column>
-          <Columns.Column className="mobile-column">
+          </div>
+          <div>
             {applicationUser && (
-              <span
-                className="mobile-application-card__link"
-                onClick={() =>
-                  history.push(
-                    `/app/applications/profile/${
-                      applicationUser && applicationUser.id
-                    }`
-                  )
-                }
-              >
-                <p>{applicationUser.fullName}</p>
-              </span>
+              <>
+                <p
+                  className="mobile-application-card__link"
+                  onClick={() =>
+                    history.push(
+                      `/app/applications/profile/${
+                        applicationUser && applicationUser.id
+                      }`
+                    )
+                  }
+                >
+                  {applicationUser.fullName}
+                </p>
+                <div className="mobile-application-card__location">
+                  <Icon
+                    icon="location"
+                    size="small"
+                    className="mobile-application-card__location-icon"
+                  />
+                  <p className="mobile-application-card__location-name">
+                    {REDI_LOCATION_NAMES[applicationUser.rediLocation]}
+                  </p>
+                </div>
+                <p className="mobile-application-card__date">
+                  Sent on {moment(applicationDate).format('DD.MM.YYYY')}
+                </p>
+              </>
             )}
-            {applicationUser && (
-              <p>{REDI_LOCATION_NAMES[applicationUser.rediLocation]}</p>
-            )}
-          </Columns.Column>
-          <Columns.Column
-            className="mobile-column"
-            textAlignment="right"
-            narrow
-            textSize={6}
-          >
-            <p
-              className={
-                application.status === MentorshipMatchStatus.Applied
-                  ? 'application-card-pending__status'
-                  : null
-              }
-            >
-              {MENTORSHIP_MATCH_STATUS_LABELS[application.status]}
-            </p>
-            <p>{moment(applicationDate).format('DD.MM.YYYY')}</p>
-          </Columns.Column>
-          <Columns.Column className="mobile-application-card-dropdown">
+          </div>
+        </div>
+
+        <div className="mobile-application-card__tag-container">
+          <div className="mobile-application-card__tag">
+            <Chip chip={MENTORSHIP_MATCH_STATUS_LABELS[application.status]} />
+          </div>
+          <div className="mobile-application-card-dropdown">
             <Icon
               icon="chevronDown"
               size="small"
               className={classnames({ 'icon--rotate': showDetails })}
             />
-          </Columns.Column>
-        </Columns>
+          </div>
+        </div>
       </div>
 
       <div

--- a/apps/redi-connect/src/pages/app/applications/application-card/useApplicationCard.ts
+++ b/apps/redi-connect/src/pages/app/applications/application-card/useApplicationCard.ts
@@ -1,9 +1,11 @@
 import {
   AllConProfileFieldsFragment,
+  MentorshipMatchStatus,
   UserType,
 } from '@talent-connect/data-access'
 import { useState } from 'react'
 import { useHistory } from 'react-router-dom'
+import { ChipVariant } from '../../../../../../../libs/shared-atomic-design-components/src/lib/atoms/Chip'
 import { ApplicationCardApplicationPropFragment } from '../../../../components/organisms/ApplicationCard.generated'
 
 interface ApplicationCardProps {
@@ -24,6 +26,24 @@ export const useApplicationCard = ({
       : application.mentee
   const currentUserIsMentor = currentUser?.userType === UserType.Mentor
 
+  const getChipVariant = (status: MentorshipMatchStatus): ChipVariant => {
+    switch (status) {
+      case MentorshipMatchStatus.Applied:
+        return 'pending'
+      case MentorshipMatchStatus.Accepted:
+      case MentorshipMatchStatus.Completed:
+        return 'default'
+      case MentorshipMatchStatus.Cancelled:
+      case MentorshipMatchStatus.DeclinedByMentor:
+      case MentorshipMatchStatus.InvalidatedAsOtherMentorAccepted:
+        return 'neutral'
+      default:
+        return 'default'
+    }
+  }
+
+  const chipVariant = getChipVariant(application.status)
+
   return {
     history,
     showDetails,
@@ -31,5 +51,6 @@ export const useApplicationCard = ({
     applicationUser,
     applicationDate,
     currentUserIsMentor,
+    chipVariant,
   }
 }

--- a/libs/shared-atomic-design-components/src/lib/atoms/CardTags.scss
+++ b/libs/shared-atomic-design-components/src/lib/atoms/CardTags.scss
@@ -2,22 +2,16 @@
 @import '~bulma/sass/utilities/_all';
 
 .chip {
-  display: flex;
-  height: 32px;
-  padding: 3px 12px;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: nowrap;
+  padding: 2px 12px;
   text-wrap: nowrap;
   border-radius: 8px;
-  background: var(--redi-orange-extra-light, #ffeae2);
+  background-color: $redi-blue-light;
 
-  color: var(--redi-orange, #ff7d55);
+  color: $black;
   font-family: Avenir LT Std;
   font-size: 14px;
   font-style: normal;
-  font-weight: 700;
+  font-weight: $weight-normal;
   line-height: 150%; /* 21px */
 }
 
@@ -30,17 +24,14 @@
 
   &__profile {
     display: flex;
-    flex-direction: column;
     align-items: flex-start;
     gap: 8px;
     flex-wrap: wrap;
 
     .chip {
-      display: inline-block;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      line-height: 200%;
       max-width: 100%;
     }
     .last_row {
@@ -57,8 +48,6 @@
 
     @include mobile() {
       .chip {
-        line-height: normal;
-        height: 24px;
         border-radius: 6px;
         font-size: 12px;
       }

--- a/libs/shared-atomic-design-components/src/lib/atoms/Chip.scss
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Chip.scss
@@ -5,14 +5,23 @@
   padding: 2px 12px;
   text-wrap: nowrap;
   border-radius: 8px;
-  background-color: $redi-blue-light;
-
-  color: $black;
+  background-color: $redi-blue-light; // default
+  color: $black; // default
   font-family: Avenir LT Std;
   font-size: 14px;
   font-style: normal;
   font-weight: $weight-normal;
   line-height: 150%; /* 21px */
+
+  &--pending {
+    background-color: $redi-orange-extra-light;
+    color: $redi-orange;
+  }
+
+  &--neutral {
+    background-color: $grey-extra-light;
+    color: $grey-dark;
+  }
 
   @include mobile() {
     overflow: hidden;

--- a/libs/shared-atomic-design-components/src/lib/atoms/Chip.scss
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Chip.scss
@@ -2,27 +2,19 @@
 @import '~bulma/sass/utilities/_all';
 
 .chip {
-  display: flex;
-  height: 32px;
-  padding: 3px 12px;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: nowrap;
+  padding: 2px 12px;
   text-wrap: nowrap;
   border-radius: 8px;
-  background: var(--redi-orange-extra-light, #ffeae2);
+  background-color: $redi-blue-light;
 
-  color: var(--redi-orange, #ff7d55);
+  color: $black;
   font-family: Avenir LT Std;
   font-size: 14px;
   font-style: normal;
-  font-weight: 700;
+  font-weight: $weight-normal;
   line-height: 150%; /* 21px */
 
   @include mobile() {
-    display: inline-block;
-    height: 24px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/libs/shared-atomic-design-components/src/lib/atoms/Chip.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Chip.tsx
@@ -1,10 +1,14 @@
+import classnames from 'classnames'
 import './Chip.scss'
 
+export type ChipVariant = 'default' | 'pending' | 'neutral'
 export interface ChipProps {
   chip: string
+  variant?: ChipVariant
 }
 
-const Chip = ({ chip }: ChipProps) => {
-  return <p className="chip">{chip}</p>
+const Chip = ({ chip, variant = 'default' }: ChipProps) => {
+  return <p className={classnames('chip', `chip--${variant}`)}>{chip}</p>
 }
+
 export default Chip

--- a/libs/shared-atomic-design-components/src/lib/atoms/FormSelect.styles.ts
+++ b/libs/shared-atomic-design-components/src/lib/atoms/FormSelect.styles.ts
@@ -13,6 +13,9 @@ export const formSelectStyles = {
     ...provided,
     svg: {
       margin: '0 0.1rem',
+      '& path': {
+        fill: 'black',
+      },
     },
   }),
   dropdownIndicator: (provided: any, state: any) => ({
@@ -21,6 +24,9 @@ export const formSelectStyles = {
     transform: state.selectProps.menuIsOpen ? 'rotate(180deg)' : 'none',
     svg: {
       margin: '0 0.1rem',
+      '& path': {
+        fill: 'black',
+      },
     },
   }),
   control: (provided: any, state: any) => ({
@@ -29,19 +35,20 @@ export const formSelectStyles = {
     minHeight: '48px',
     boxShadow: 'inset 0 2px 6px rgba(178, 180, 181, 0.3)',
     '&:hover': {
-      borderColor: 'black'
+      borderColor: 'black',
     },
   }),
   multiValue: (provided: any) => ({
     ...provided,
-    color: '#FFB298',
-    borderRadius: '4px',
-    backgroundColor: '#FFEAE2',
+    color: 'black',
+    fontSize: '14px',
+    borderRadius: '8px',
+    backgroundColor: '#daf0f4',
   }),
   multiValueLabel: (provided: any) => ({
     ...provided,
     fontSize: 'inherit',
-    color: '#FF7D55',
+    color: 'black',
   }),
   placeholder: (provided: any) => ({
     ...provided,
@@ -50,8 +57,14 @@ export const formSelectStyles = {
   }),
   multiValueRemove: (provided: any) => ({
     ...provided,
+    '&:hover': {
+      backgroundColor: '#84c5d2',
+    },
     svg: {
       padding: '0 2px',
+      '& path': {
+        fill: 'black',
+      },
     },
   }),
   menuPortal: (base) => ({ ...base, zIndex: 9999 }),

--- a/libs/shared-atomic-design-components/src/lib/atoms/Icon.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Icon.tsx
@@ -29,6 +29,7 @@ import { ReactComponent as Instagram } from '../../assets/images/instagram.svg'
 import { ReactComponent as Link } from '../../assets/images/link.svg'
 import { ReactComponent as Linkedin } from '../../assets/images/linkedin.svg'
 import { ReactComponent as Loader } from '../../assets/images/loader.svg'
+import { ReactComponent as Location } from '../../assets/images/location.svg'
 import { ReactComponent as Mail } from '../../assets/images/mail.svg'
 import { ReactComponent as MapPin } from '../../assets/images/map-pin.svg'
 import { ReactComponent as Meetup } from '../../assets/images/meetup.svg'
@@ -79,6 +80,7 @@ const Icons = {
   fb: Fb,
   linkedin: Linkedin,
   loader: Loader,
+  location: Location,
   mapPin: MapPin,
   stepDisabled: StepDisabled,
   stepProgress: StepProgress,

--- a/libs/shared-config/src/lib/config.ts
+++ b/libs/shared-config/src/lib/config.ts
@@ -1,10 +1,10 @@
 export const REDI_LOCATION_NAMES = {
-  BERLIN: 'Berlin',
-  HAMBURG: 'Hamburg',
-  MALMO: 'Malmö',
-  MUNICH: 'Munich',
-  NRW: 'NRW',
-  CYBERSPACE: 'Cyberspace',
+  BERLIN: 'ReDI Berlin',
+  HAMBURG: 'ReDI Hamburg',
+  MALMO: 'ReDI Malmö',
+  MUNICH: 'ReDI Munich',
+  NRW: 'ReDI NRW',
+  CYBERSPACE: 'ReDI Online in Germany',
 } as const
 
 export const CATEGORY_GROUPS = {


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

In this PR, we:

- Changed the naming of the Cyberspace location and aligned it in multiple places
- Styled Chip and FormSelect components according to the new design system
- Styled the mentee application card according to the new design suggested by Becky
- Added chip/tag variants for different statuses of the mentee application card

## Screenshots

ReDI location dropdown on the CON/TP sign-up page:
<img width="615" height="434" alt="image" src="https://github.com/user-attachments/assets/325f59b7-23ca-474a-9368-673f8504b301" />

ReDI location dropdown on the 'Find a mentor' page:
<img width="301" height="283" alt="image" src="https://github.com/user-attachments/assets/3c4ee75a-43da-403f-93d5-99e864fdb4d2" />

Tags on the mentee/mentor profile page:
<img width="1253" height="827" alt="image" src="https://github.com/user-attachments/assets/7d5bc13b-dc03-43a3-9688-685fcc4f2ffc" />

Tags in the multiselect dropdown:
<img width="943" height="691" alt="image" src="https://github.com/user-attachments/assets/d6f478ba-047b-4dbf-9483-3beadb8e0f08" />

Tags on the mentor profile card (desktop):
<img width="298" height="500" alt="image" src="https://github.com/user-attachments/assets/89eab4e6-9da0-48cc-8a76-b621a8648e5c" />

Tags on the mentor profile card (mobile):
<img width="365" height="374" alt="image" src="https://github.com/user-attachments/assets/b7c2d471-60fa-447d-813f-d48b26f0a12c" />


ReDI location & tags on the mentor profile view:
<img width="1029" height="836" alt="image" src="https://github.com/user-attachments/assets/67cc6421-5443-4f19-b94e-94edd7f6c691" />

New design of the application card (desktop):
<img width="1027" height="833" alt="image" src="https://github.com/user-attachments/assets/3ce60b7a-8cf0-44e2-9a76-24107fe79c28" />

New design of the application card (mobile):
<img width="448" height="826" alt="image" src="https://github.com/user-attachments/assets/b98ac930-9364-44e7-91fb-e4415da7f136" />

Tags on the jobseeker profile card (desktop):
<img width="1073" height="539" alt="image" src="https://github.com/user-attachments/assets/7e5a1724-bf82-436d-837a-195be5532455" />

Tags on the jobseeker profile card (mobile):
<img width="361" height="391" alt="image" src="https://github.com/user-attachments/assets/d62ed7e5-e66b-4d95-9a34-86e591fd53dc" />

Tags on the job listing card (desktop):
<img width="1077" height="237" alt="image" src="https://github.com/user-attachments/assets/89fcb490-acd3-485c-b039-40f2d24aa032" />

Tags on the job listing card (mobile):
<img width="358" height="351" alt="image" src="https://github.com/user-attachments/assets/6e26bdae-3d43-4570-8844-09f913a824e0" />

Tags on the job listing page (desktop):
<img width="1034" height="680" alt="image" src="https://github.com/user-attachments/assets/ec80d38f-fee6-4d6b-a7cd-b24e1b3c43b1" />

Tags on the job listing page (mobile):
<img width="496" height="537" alt="image" src="https://github.com/user-attachments/assets/8d0a075c-2b7c-485c-b7e8-48525ddf0b45" />
